### PR TITLE
fix: make refreshPanel stub async to match ReviewMediator interface

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -48,7 +48,7 @@ function init(): void {
   // Typed mediator — createPanel and createAnnotator wire up their
   // implementations; stubs here are replaced before first use.
   const mediator: ReviewMediator = {
-    refreshPanel: () => {},
+    refreshPanel: async () => {},
     restoreHighlights: async () => {},
   };
 


### PR DESCRIPTION
The mediator stub for `refreshPanel` was typed as `() => void` but the
`ReviewMediator` interface requires `() => Promise<void>`, causing
`tsc --noEmit` to fail in CI.

https://claude.ai/code/session_018LhHM1NwhfyLAmV87mRjgA