### PR TITLE
feat: Accept button clears annotation; hide Delete when workflow buttons present

### DIFF
--- a/docs/engineering-plans/2026-02-27-accept-clears-annotation.md
+++ b/docs/engineering-plans/2026-02-27-accept-clears-annotation.md
@@ -1,0 +1,59 @@
+---
+generated_by: Claude Opus 4.6
+generation_date: 2026-02-27
+model_version: claude-opus-4-6
+purpose: implementation_plan
+status: complete
+human_reviewer: matthewvivian
+tags: [panel, buttons, accept, delete, workflow]
+---
+
+# Accept Button Should Clear Annotation (#25)
+
+## Problem
+
+The Accept button on addressed annotations transitions to `resolved` status, leaving the annotation visible at reduced opacity. This adds clutter without value — if the reviewer has approved a change, the annotation should disappear.
+
+## Desired Behaviour
+
+| Status | Buttons shown | Accept action |
+|--------|--------------|---------------|
+| `open` | Delete | — |
+| `addressed` | Accept | **Deletes the annotation entirely** |
+| `resolved` | Reopen | — |
+
+Key changes:
+1. **Accept = delete**: clicking Accept on an addressed annotation removes it completely
+2. **Delete button only in `open` status**: once workflow buttons (Accept/Reopen) are present, the Delete button is hidden
+
+## Implementation
+
+### Session 1: Implementation
+
+#### Files to modify
+
+1. **`src/client/ui/panel.ts`**
+   - `appendStatusActions()` (line ~708-710): Change Accept button click handler from `callbacks.onAnnotationStatusChange(id, 'resolved')` to `callbacks.onAnnotationDelete(id)`
+   - `createTextAnnotationItem()` (lines ~421-424): Only append delete button when `status === 'open'`
+   - `createElementAnnotationItem()` (lines ~485-488): Same conditional for element annotations
+
+2. **`src/client/index.ts`**
+   - No changes needed — `onAnnotationDelete` callback already handles API deletion, highlight removal, badge refresh, and panel refresh
+
+3. **`tests/client/ui/panel.test.ts`**
+   - Update test "Accept button calls onAnnotationStatusChange with resolved" → should now call `onAnnotationDelete`
+   - Add tests: Delete button hidden on addressed annotations
+   - Add tests: Delete button hidden on resolved annotations
+   - Add tests: Delete button visible on open annotations
+
+4. **`docs/spec/specification.md`** (section 6.2.3c)
+   - Update Accept button description: deletes annotation instead of transitioning to resolved
+   - Update button visibility table: Delete only shown in `open` status
+
+#### Approach (TDD)
+1. Write failing tests first
+2. Implement changes to pass tests
+3. Update specification
+4. Run full test suite + lint
+5. Create independent review
+6. Create PR

--- a/docs/reviews/2026-02-27-accept-clears-annotation-review.md
+++ b/docs/reviews/2026-02-27-accept-clears-annotation-review.md
@@ -1,0 +1,61 @@
+---
+generated_by: Claude Opus 4.6
+generation_date: 2026-02-27
+model_version: claude-opus-4-6
+purpose: code_review
+status: complete
+human_reviewer: matthewvivian
+tags: [review, panel, accept-button, delete-button]
+---
+
+# Code Review: Accept Button Clears Annotation (#25)
+
+## Scope
+
+Review of changes to make the Accept button delete annotations instead of transitioning to `resolved` status, and to hide the Delete button when workflow buttons are present.
+
+## Files Changed
+
+| File | Change Type | Lines Changed |
+|------|-------------|---------------|
+| `src/client/ui/panel.ts` | Behaviour change | ~6 lines |
+| `tests/client/ui/panel.test.ts` | Test update + additions | ~40 lines |
+| `docs/spec/specification.md` | Spec update | ~15 lines |
+| `docs/engineering-plans/2026-02-27-accept-clears-annotation.md` | New | Engineering plan |
+
+## Review Findings
+
+### Correctness
+
+- **Accept button handler**: Changed from `onAnnotationStatusChange(id, 'resolved')` to `onAnnotationDelete(id)`. The `onAnnotationDelete` callback (in `src/client/index.ts:89-99`) correctly handles API deletion, highlight removal, badge refresh, and panel refresh. No changes needed to the callback itself.
+
+- **Delete button visibility**: Conditional `if (status === 'open')` correctly gates the delete button in both `createTextAnnotationItem` and `createElementAnnotationItem`. The three states are mutually exclusive, so this is safe.
+
+- **No regression risk**: The `onAnnotationStatusChange` callback is still used by the Reopen button, so removing the Accept button's usage of it doesn't break anything.
+
+### Test Coverage
+
+- Updated existing test to verify Accept calls `onAnnotationDelete` instead of `onAnnotationStatusChange`
+- Added explicit assertion that `onAnnotationStatusChange` is NOT called when Accept is clicked
+- Added tests for Delete button hidden on `addressed` and `resolved` statuses
+- Added test confirming Delete button visible only on `open` annotations
+- All 431 tests pass (56 in panel test file)
+
+### Spec Consistency
+
+- Section 6.2.3c updated with new button/action table
+- Delete button descriptions in sections 6.2.3 and 6.2.3a updated to mention `open` status restriction
+- Data element table entry for `annotation-delete` updated
+- User interaction table updated for Accept action
+
+### Edge Cases Considered
+
+1. **MCP `resolve_annotation` tool**: Still works — it sets `addressed` status, not `resolved`. The Accept button now deletes rather than resolves, but the MCP tool's `autoResolve: true` option still works independently of the UI button. No changes needed to MCP tools.
+
+2. **Resolved annotations**: Can still be reached via MCP `autoResolve: true` or direct API `PATCH`. The Reopen button on resolved annotations is unchanged.
+
+3. **Clear All**: Still deletes all annotations regardless of status — not affected by this change since it operates directly via the API, not through status action buttons.
+
+## Verdict
+
+Changes are minimal, well-tested, and correctly scoped. No issues found.

--- a/docs/spec/specification.md
+++ b/docs/spec/specification.md
@@ -907,7 +907,7 @@ Each text annotation item in the panel shows:
 
 **Status action buttons**: Each annotation item includes contextual action buttons based on its status (see 6.2.3c).
 
-**Delete button**: Each text annotation item has a "Delete" button (`data-air-el="annotation-delete"`) with a two-click confirmation flow matching the Clear All pattern (section 6.2.5). First click changes the button text to "Sure?" and sets `data-air-state="confirming"`. A second click within 3 seconds executes the delete (calls the API, removes highlight marks, refreshes badge and panel). If no second click occurs within 3 seconds, the button reverts to "Delete".
+**Delete button**: Each text annotation item in `open` status has a "Delete" button (`data-air-el="annotation-delete"`) with a two-click confirmation flow matching the Clear All pattern (section 6.2.5). First click changes the button text to "Sure?" and sets `data-air-state="confirming"`. A second click within 3 seconds executes the delete (calls the API, removes highlight marks, refreshes badge and panel). If no second click occurs within 3 seconds, the button reverts to "Delete". The Delete button is hidden when workflow buttons (Accept, Reopen) are present — see section 6.2.3c.
 
 **Orphan indicator**: If the annotation's text cannot be located on the page (Tier 4 orphan per section 8.4), a red indicator is shown with the text "Could not locate on page" (class `.air-annotation-item__orphan`). The item container receives the `.air-annotation-item--orphan` modifier class, which adds a red left border and reduced opacity. Orphan detection only applies to annotations on the current page — annotations for other pages (shown in the "All Pages" tab) do not show an orphan indicator since their DOM is not available.
 
@@ -926,7 +926,7 @@ Each element annotation item in the panel shows:
 
 **Status action buttons**: Same contextual action buttons as text annotations (see 6.2.3c).
 
-**Delete button**: Each element annotation item has a "Delete" button (`data-air-el="annotation-delete"`) with the same two-click confirmation flow as text annotations (section 6.2.3). First click shows "Sure?" with `data-air-state="confirming"`, second click within 3 seconds executes the delete.
+**Delete button**: Each element annotation item in `open` status has a "Delete" button (`data-air-el="annotation-delete"`) with the same two-click confirmation flow as text annotations (section 6.2.3). First click shows "Sure?" with `data-air-state="confirming"`, second click within 3 seconds executes the delete. Hidden when workflow buttons are present — see section 6.2.3c.
 
 **Orphan indicator**: If the annotated element cannot be found on the page (its highlight was not restored), a red indicator is shown with the text "Could not locate on page". The item receives the `.air-annotation-item--orphan` modifier class. Same current-page-only restriction as text annotations (section 6.2.3).
 
@@ -946,15 +946,15 @@ The badge appears at the top of the annotation item, above the selected text/ele
 
 #### 6.2.3c Status Action Buttons
 
-Each annotation item includes contextual action buttons based on its effective status:
+Each annotation item includes contextual action buttons based on its effective status. The Delete button (section 6.2.3d) is only shown when no workflow buttons are present (i.e., in `open` status):
 
-| Status | Button shown | Label | `data-air-el` | Action |
-|--------|-------------|-------|---------------|--------|
-| `addressed` | Accept | "Accept" | `annotation-accept` | Transitions annotation to `resolved` via `PATCH` with `status: 'resolved'` |
+| Status | Buttons shown | Label | `data-air-el` | Action |
+|--------|--------------|-------|---------------|--------|
+| `open` | Delete | "Delete" | `annotation-delete` | Two-click delete (see section 6.2.3d) |
+| `addressed` | Accept | "Accept" | `annotation-accept` | Deletes annotation entirely via `DELETE /annotations/:id` |
 | `resolved` | Reopen | "Reopen" | `annotation-reopen` | Transitions annotation to `open` via `PATCH` with `status: 'open'` |
-| `open` | — | — | — | No status action button |
 
-**Accept button**: Green background (`#166534`), green text (`#86EFAC`). Used by the human reviewer to confirm that the agent's work is satisfactory. Sends `PATCH /annotations/:id` with `{ "status": "resolved" }`, then restores highlights (to update colours), refreshes badge, and refreshes panel.
+**Accept button**: Green background (`#166534`), green text (`#86EFAC`). Used by the human reviewer to confirm that the agent's work is satisfactory. Sends `DELETE /annotations/:id`, removes highlights, refreshes badge, and refreshes panel. The annotation is removed entirely — accepting means the reviewer is happy with the change and the annotation has served its purpose.
 
 **Reopen button**: Styled as a cancel-type button. Used when the reviewer disagrees with the resolution and wants to re-open the annotation. Sends `PATCH /annotations/:id` with `{ "status": "open" }`, then restores highlights, refreshes badge, and refreshes panel.
 
@@ -1556,7 +1556,7 @@ The integration exposes stable `data-air-el` and `data-air-state` attributes for
 | `page-note-save` | Page note form save button | Shadow DOM | Present when add/edit note form is open |
 | `clear-all` | "Clear All" button | Shadow DOM | Always present (child of panel header) |
 | `toast` | Toast notification | Shadow DOM | Created on first toast, then reused |
-| `annotation-delete` | Annotation delete button | Shadow DOM | Present on each annotation item when panel shows annotations |
+| `annotation-delete` | Annotation delete button | Shadow DOM | Present on open-status annotation items only (hidden when workflow buttons shown) |
 | `element-annotation-item` | Element annotation list item in panel | Shadow DOM | Present when panel is open and element annotations exist |
 | `panel-content` | Panel content area (scrollable) | Shadow DOM | Always present (child of panel) |
 | `status-badge` | Status badge on annotation (addressed or resolved) | Shadow DOM | Present on non-open annotations |
@@ -1821,7 +1821,7 @@ The following accessibility features are not yet implemented:
 | Click element annotation in panel | Page scrolls to element, outline pulses | 6.2.3a, 8.5.3 |
 | Click "+ Note" in panel | Add-note form appears/toggles | 11.2 |
 | Click "Copy All" in panel | Export all annotations to clipboard, show toast | 9.3 |
-| Click Accept on addressed annotation | Annotation status changes to resolved, highlights update colours | 6.2.3c, 3.2.5 |
+| Click Accept on addressed annotation | Annotation is deleted entirely (removed from store, highlights cleared) | 6.2.3c |
 | Click Reopen on resolved annotation | Annotation status changes to open, highlights update colours | 6.2.3c, 3.2.5 |
 | Click Delete on annotation in panel | Two-click confirmation: first click shows "Sure?", second click deletes | 6.2.3, 6.2.3a |
 | Click "Clear All" in panel | Confirmation step, then deletes all | 6.2.5 |

--- a/src/client/ui/panel.ts
+++ b/src/client/ui/panel.ts
@@ -420,8 +420,10 @@ function createTextAnnotationItem(annotation: TextAnnotation, callbacks: PanelCa
 
   appendStatusActions(actions, annotation.id, status, callbacks);
 
-  const deleteBtn = createDeleteButton(annotation.id, callbacks);
-  actions.appendChild(deleteBtn);
+  if (status === 'open') {
+    const deleteBtn = createDeleteButton(annotation.id, callbacks);
+    actions.appendChild(deleteBtn);
+  }
 
   item.appendChild(actions);
 
@@ -484,8 +486,10 @@ function createElementAnnotationItem(annotation: Annotation & { type: 'element' 
 
   appendStatusActions(actions, annotation.id, status, callbacks);
 
-  const deleteBtn = createDeleteButton(annotation.id, callbacks);
-  actions.appendChild(deleteBtn);
+  if (status === 'open') {
+    const deleteBtn = createDeleteButton(annotation.id, callbacks);
+    actions.appendChild(deleteBtn);
+  }
 
   item.appendChild(actions);
 
@@ -707,7 +711,7 @@ function appendStatusActions(
     acceptBtn.style.fontSize = '11px';
     acceptBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      callbacks.onAnnotationStatusChange(annotationId, 'resolved');
+      callbacks.onAnnotationDelete(annotationId);
     });
     container.appendChild(acceptBtn);
   }

--- a/tests/client/ui/panel.test.ts
+++ b/tests/client/ui/panel.test.ts
@@ -1018,7 +1018,7 @@ describe('createPanel — status lifecycle buttons', () => {
     expect(reopenBtn).toBeNull();
   });
 
-  it('Accept button calls onAnnotationStatusChange with resolved', async () => {
+  it('Accept button calls onAnnotationDelete to remove annotation', async () => {
     await renderWithStore({
       version: 1,
       annotations: [makeTextAnnotation({ id: 'accept-me', status: 'addressed', addressedAt: '2026-02-22T10:00:00Z' })],
@@ -1028,7 +1028,47 @@ describe('createPanel — status lifecycle buttons', () => {
     const acceptBtn = shadowRoot.querySelector('[data-air-el="annotation-accept"]') as HTMLButtonElement;
     acceptBtn.click();
 
-    expect(callbacks.onAnnotationStatusChange).toHaveBeenCalledWith('accept-me', 'resolved');
+    expect(callbacks.onAnnotationDelete).toHaveBeenCalledWith('accept-me');
+    expect(callbacks.onAnnotationStatusChange).not.toHaveBeenCalled();
+  });
+
+  it('hides Delete button when Accept button is shown (addressed status)', async () => {
+    await renderWithStore({
+      version: 1,
+      annotations: [makeTextAnnotation({ status: 'addressed', addressedAt: '2026-02-22T10:00:00Z' })],
+      pageNotes: [],
+    });
+
+    const deleteBtn = shadowRoot.querySelector('[data-air-el="annotation-delete"]');
+    expect(deleteBtn).toBeNull();
+  });
+
+  it('hides Delete button when Reopen button is shown (resolved status)', async () => {
+    await renderWithStore({
+      version: 1,
+      annotations: [makeTextAnnotation({ status: 'resolved', resolvedAt: '2026-02-22T10:00:00Z' })],
+      pageNotes: [],
+    });
+
+    const deleteBtn = shadowRoot.querySelector('[data-air-el="annotation-delete"]');
+    expect(deleteBtn).toBeNull();
+  });
+
+  it('shows Delete button only on open annotations', async () => {
+    await renderWithStore({
+      version: 1,
+      annotations: [makeTextAnnotation()],
+      pageNotes: [],
+    });
+
+    const deleteBtn = shadowRoot.querySelector('[data-air-el="annotation-delete"]');
+    expect(deleteBtn).not.toBeNull();
+
+    const acceptBtn = shadowRoot.querySelector('[data-air-el="annotation-accept"]');
+    expect(acceptBtn).toBeNull();
+
+    const reopenBtn = shadowRoot.querySelector('[data-air-el="annotation-reopen"]');
+    expect(reopenBtn).toBeNull();
   });
 
   it('Reopen button calls onAnnotationStatusChange with open', async () => {


### PR DESCRIPTION
## Summary

- **Accept = delete**: clicking Accept on an addressed annotation now removes it entirely (DELETE request) instead of transitioning to resolved status
- **Delete button only in open status**: the Delete button is hidden when workflow buttons (Accept/Reopen) are present, giving each status a single clear action

## Changes

| Status | Buttons shown | Action |
|--------|--------------|--------|
| `open` | Delete | Two-click delete |
| `addressed` | Accept | **Deletes annotation entirely** |
| `resolved` | Reopen | Transitions to open |

### Files changed

- `src/client/ui/panel.ts` — Accept handler calls `onAnnotationDelete`; delete button gated by `status === 'open'`
- `tests/client/ui/panel.test.ts` — Updated Accept test + 3 new delete-visibility tests (56 total, all pass)
- `docs/spec/specification.md` — Updated sections 6.2.3, 6.2.3a, 6.2.3c, data-air-el table, interaction table
- `docs/engineering-plans/2026-02-27-accept-clears-annotation.md` — Engineering plan
- `docs/reviews/2026-02-27-accept-clears-annotation-review.md` — Independent review

## Test plan

- [x] All 431 tests pass (56 panel tests including 4 new/updated)
- [x] Build succeeds
- [x] Lint passes
- [x] Manual: open annotation shows Delete button only
- [x] Manual: addressed annotation shows Accept button only, clicking it removes annotation
- [ ] Manual: resolved annotation shows Reopen button only

Closes #25