### PR TITLE
fix: show Reopen button on addressed annotations

### DIFF
--- a/docs/guides/2026-02-28-annotation-status-workflows.md
+++ b/docs/guides/2026-02-28-annotation-status-workflows.md
@@ -1,0 +1,294 @@
+---
+generated_by: Claude Opus 4.6
+generation_date: 2026-02-28
+model_version: claude-opus-4-6
+purpose: developer_guide
+status: draft
+human_reviewer: matthewvivian
+tags: [status, workflow, annotations, lifecycle, guide]
+---
+
+# Annotation Status Workflows
+
+Canonical guide to the annotation status lifecycle in astro-inline-review. Covers all statuses, transitions, UI behaviour, MCP agent integration, and edge cases.
+
+## Status Model
+
+There are exactly four annotation statuses, defined in `src/shared/types.ts`:
+
+```typescript
+type AnnotationStatus = 'open' | 'in_progress' | 'addressed' | 'resolved';
+```
+
+| Status | Meaning | Set By |
+|--------|---------|--------|
+| `open` | New annotation, or reopened by reviewer | Default on creation; reviewer via Reopen button |
+| `in_progress` | Agent is actively working on the annotation | Agent via MCP `set_in_progress` tool |
+| `addressed` | Agent has acted on the annotation (awaiting human review) | Agent via MCP `resolve_annotation` (default) |
+| `resolved` | Agent auto-resolved, skipping human review | Agent via MCP `resolve_annotation` with `autoResolve: true` |
+
+### Status Storage
+
+Status is stored explicitly in the `status` field on each annotation. For backward compatibility, annotations without a `status` field are derived using `getAnnotationStatus()`:
+
+- If `resolvedAt` timestamp exists: `'resolved'`
+- Otherwise: `'open'`
+
+## Lifecycle Diagrams
+
+### Happy Path: Default Agent Workflow
+
+The most common flow. Agent uses `resolve_annotation` without `autoResolve`, producing `addressed` status.
+
+```
+  Reviewer creates annotation
+          |
+          v
+     +---------+
+     |  OPEN   |  Buttons: [Delete]
+     +----+----+
+          |  Agent calls set_in_progress (MCP)
+          v
+  +---------------+
+  |  IN_PROGRESS  |  Buttons: [NONE]  Badge: "Agent working..."
+  +-------+-------+
+          |  Agent calls resolve_annotation (MCP, default)
+          v
+  +---------------+
+  |   ADDRESSED   |  Buttons: [Accept] [Reopen]  Badge: "Addressed"
+  +-------+-------+
+          |
+     +----+----+
+     v         v
+  Accept    Reopen (shows textarea for follow-up note)
+     |         |
+     v         v
+  DELETED   +---------+
+            |  OPEN   |  + optional reviewer reply appended
+            +---------+
+```
+
+### Auto-Resolve Path
+
+Agent uses `resolve_annotation` with `autoResolve: true`, skipping human review.
+
+```
+  Reviewer creates annotation
+          |
+          v
+     +---------+
+     |  OPEN   |  Buttons: [Delete]
+     +----+----+
+          |  Agent calls set_in_progress (MCP)
+          v
+  +---------------+
+  |  IN_PROGRESS  |  Buttons: [NONE]
+  +-------+-------+
+          |  Agent calls resolve_annotation(autoResolve: true)
+          v
+  +---------------+
+  |   RESOLVED    |  Buttons: [Accept] [Reopen]  Badge: "Resolved"
+  +-------+-------+
+          |
+     +----+----+
+     v         v
+  Accept    Reopen (shows textarea for follow-up note)
+     |         |
+     v         v
+  DELETED   +---------+
+            |  OPEN   |  + optional reviewer reply appended
+            +---------+
+```
+
+### All Possible Transitions
+
+```
+              +----------+
+  +---------->|   OPEN   |<---------- Reopen -----------+
+  |           +-----+----+        (from addressed       |
+  |                 |              or resolved)          |
+  |            set_in_progress                           |
+  |                 |                                    |
+  |                 v                                    |
+  |        +--------------+                              |
+  |        | IN_PROGRESS  |                              |
+  |        +------+-------+                              |
+  |               |                                      |
+  |        resolve_annotation                            |
+  |        (default)                                     |
+  |               |                                      |
+  |               v                                      |
+  |        +------------+                                |
+  |        |  ADDRESSED |-------- Reopen ----------------+
+  |        +------+-----+                                |
+  |               |                                      |
+  |          Accept (deletes)                            |
+  |               |                                      |
+  |               v           resolve_annotation         |
+  |          +==========+     (autoResolve: true)        |
+  +----------|  DELETED  |    from any status             |
+             +==========+           |                    |
+                                    v                    |
+                             +------------+              |
+                             |  RESOLVED  |----- Reopen -+
+                             +------+-----+
+                                    |
+                               Accept (deletes)
+                                    |
+                                    v
+                              +==========+
+                              |  DELETED  |
+                              +==========+
+```
+
+### Button Visibility Matrix
+
+```
++--------------+---------+---------+---------+-------------+
+|   Status     | Delete  | Accept  | Reopen  | Status Badge|
++--------------+---------+---------+---------+-------------+
+| open         |   Yes   |   No    |   No    |   (none)    |
+| in_progress  |   No    |   No    |   No    |  "Working"  |
+| addressed    |   No    |   Yes   |   Yes   |  "Addressed"|
+| resolved     |   No    |   Yes   |   Yes   |  "Resolved" |
++--------------+---------+---------+---------+-------------+
+```
+
+## MCP Agent Integration
+
+### Recommended Agent Workflow
+
+```
+1. set_in_progress(id)         -- Signal work starting
+        |
+2. (edit source code)          -- Make changes
+        |
+3. add_agent_reply(id, msg)    -- Optional: log progress notes
+        |
+4. resolve_annotation(id)     -- Mark work complete
+        |
+   Options:
+     - Default (no autoResolve):  status -> "addressed"
+     - autoResolve: true:         status -> "resolved"
+     - replacedText: "new text":  Record what replaced the original
+```
+
+### MCP Tools Reference
+
+| Tool | Effect | Status After |
+|------|--------|--------------|
+| `set_in_progress` | Signals agent is working; UI shows grace period | `in_progress` |
+| `add_agent_reply` | Appends reply to timeline; no status change | (unchanged) |
+| `resolve_annotation` (default) | Marks agent's work complete, awaiting review | `addressed` |
+| `resolve_annotation` (autoResolve) | Marks complete, skips human review | `resolved` |
+| `update_annotation_target` | Updates `replacedText` for re-anchoring | (unchanged) |
+
+### When to Use autoResolve
+
+- **Default (addressed)**: Use when the reviewer should confirm the change. This is the recommended default for most agent workflows.
+- **autoResolve: true (resolved)**: Use for trivial or mechanical changes where human review adds no value (e.g., typo fixes, formatting corrections).
+
+## Timestamp Management
+
+Each status transition sets specific timestamps and clears others:
+
+```
+  Transition to:      | inProgressAt | addressedAt  | resolvedAt
+  ---------------------+--------------+--------------+-----------
+  open                 |   CLEARED    |   CLEARED    |  CLEARED
+  in_progress          |   SET (now)  |   CLEARED    |  CLEARED
+  addressed            |   CLEARED    |   SET (now)  |  CLEARED
+  resolved             |   CLEARED    |   PRESERVED  |  SET (now)
+```
+
+Notable: `addressedAt` is **preserved** when transitioning to `resolved`. This records when the agent first acted on the annotation, even if it was later auto-resolved.
+
+## Reviewer Actions
+
+### Accept Button
+
+- **Shown on**: `addressed` and `resolved` annotations
+- **Action**: Deletes the annotation entirely (removes from store)
+- **Use case**: Reviewer is satisfied with the agent's work
+
+### Reopen Button
+
+- **Shown on**: `addressed` and `resolved` annotations
+- **Action**: Shows an inline textarea for an optional follow-up note, then transitions status to `open`
+- **Follow-up note**: Appended to the `replies` array with `role: 'reviewer'`
+- **Effect**: Clears all timestamps (`inProgressAt`, `addressedAt`, `resolvedAt`)
+
+### Delete Button
+
+- **Shown on**: `open` annotations only
+- **Action**: Two-click confirmation ("Sure?"), then deletes the annotation
+- **Hidden when**: Workflow buttons (Accept/Reopen) are present
+
+## Reply System
+
+Annotations have a `replies` array that serves as a chronological conversation thread:
+
+```typescript
+interface AgentReply {
+  message: string;
+  createdAt: string;               // ISO 8601
+  role?: 'agent' | 'reviewer';    // Defaults to 'agent'
+}
+```
+
+- **Agent replies**: Added via MCP `add_agent_reply` tool (no `role` field, defaults to `'agent'`)
+- **Reviewer replies**: Added when reopening with a follow-up note (`role: 'reviewer'`)
+- **Display**: Panel shows "Agent:" or "Reviewer:" prefix; markdown export uses the same prefixes
+
+## Orphan Tracking
+
+When annotations lose their DOM anchor (e.g., after a Vite hot-reload), the `OrphanTracker` manages a grace period:
+
+```
+  isDomAnchored?
+     |
+  +--+--+
+  | Yes  | --> 'anchored' (highlight visible)
+  +------+
+  | No   |
+  +--+---+
+     |
+  status === 'in_progress'?
+     |
+  +--+--+
+  | Yes  | --> 'checking' (indefinite — never times out)
+  +------+
+  | No   |
+  +--+---+
+     |
+  Ever been anchored on this page?
+     |
+  +--+--+
+  | No   | --> 'orphaned' (immediate — no grace period)
+  +------+
+  | Yes  |
+  +--+---+
+     |
+  Within 15-second grace period?
+     |
+  +--+--+
+  | Yes  | --> 'checking' (showing "Checking..." indicator)
+  +------+
+  | No   | --> 'orphaned' (showing "Could not locate on page")
+  +------+
+```
+
+## Key File Paths
+
+| File | Role |
+|------|------|
+| `src/shared/types.ts` | Status type definitions, `getAnnotationStatus()` |
+| `src/server/storage.ts` | `ReviewStorage` class (JSON file I/O) |
+| `src/server/middleware.ts` | REST API, status validation, timestamp management |
+| `src/client/ui/panel.ts` | Button rendering, `appendStatusActions()`, reopen form |
+| `src/client/index.ts` | Status change callback wiring |
+| `src/client/orphan-tracker.ts` | Grace period logic for orphaned annotations |
+| `src/shared/export.ts` | Markdown export with status badges |
+| `src/mcp/tools/resolve-annotation.ts` | MCP resolve tool (addressed/resolved) |
+| `src/mcp/tools/set-in-progress.ts` | MCP in_progress tool |
+| `src/mcp/tools/add-agent-reply.ts` | MCP reply tool |

--- a/docs/reviews/2026-02-28-annotation-status-workflow-review.md
+++ b/docs/reviews/2026-02-28-annotation-status-workflow-review.md
@@ -1,0 +1,207 @@
+---
+generated_by: Claude Opus 4.6
+generation_date: 2026-02-28
+model_version: claude-opus-4-6
+purpose: issue_review
+status: draft
+human_reviewer: matthewvivian
+tags: [status, workflow, reopen, addressed, review, gap-analysis]
+---
+
+# Annotation Status Workflow Review
+
+Review of the annotation status system following the merge of PR #32 (follow-up notes on reopen) and PR #33 (in_progress status and orphan grace period). Identifies a design gap where `addressed` annotations lack a Reopen option.
+
+## Context
+
+Two features were developed in parallel and merged within 12 minutes of each other:
+
+- **PR #33** (merged 08:53 UTC): Added `in_progress` status, orphan grace period, `set_in_progress` MCP tool
+- **PR #32** (merged 09:05 UTC): Added follow-up notes when reopening annotations, role-aware replies
+
+Both PRs built on PR #30 which introduced the Accept button. The merge conflict resolution (commit `ca61cf8`) integrated both features cleanly — all 476 tests pass and the build succeeds.
+
+## Current State
+
+### Button Visibility by Status
+
+```
++--------------+---------+---------+---------+
+|   Status     | Delete  | Accept  | Reopen  |
++--------------+---------+---------+---------+
+| open         |   Yes   |   No    |   No    |
+| in_progress  |   No    |   No    |   No    |
+| addressed    |   No    |   Yes   |   NO    | <-- Gap
+| resolved     |   No    |   Yes   |   Yes   |
++--------------+---------+---------+---------+
+```
+
+### MCP Agent Default Produces `addressed`
+
+The MCP `resolve_annotation` tool defaults to `addressed` status (without `autoResolve`). This is the recommended and most common agent workflow:
+
+```
+  set_in_progress(id)
+       |
+  (edit source code)
+       |
+  resolve_annotation(id)          <-- no autoResolve
+       |
+  Result: status = "addressed"    <-- only Accept button, NO Reopen
+```
+
+## Issue #1: No Reopen on `addressed` Annotations
+
+### Problem
+
+When an annotation has `addressed` status, the reviewer's only option is **Accept** (which deletes the annotation). There is no way to reopen it with feedback.
+
+This is the most common scenario because the default MCP `resolve_annotation` call produces `addressed` status. Reviewers who disagree with the agent's work must delete the annotation and create a new one from scratch, losing the entire conversation history.
+
+### Root Cause
+
+In `src/client/ui/panel.ts`, the `appendStatusActions()` function (line 743) only renders the Reopen button for `resolved` status:
+
+```typescript
+// Accept: shown on addressed OR resolved
+if (status === 'addressed' || status === 'resolved') {
+  // ... Accept button
+}
+
+// Reopen: shown ONLY on resolved  <-- THE GAP
+if (status === 'resolved') {
+  // ... Reopen button
+}
+```
+
+### Impact
+
+```
+  Agent resolves annotation (default)
+       |
+       v
+  Status: "addressed"
+       |
+  Reviewer sees: [Accept]
+       |
+  Reviewer disagrees with agent's work
+       |
+  Options:
+    1. Accept (deletes annotation) --> loses history
+    2. Create new annotation       --> loses conversation thread
+    3. Nothing                     --> annotation stays "addressed" forever
+```
+
+### Proposed Fix
+
+Change line 743 in `appendStatusActions()` from:
+
+```typescript
+if (status === 'resolved') {
+```
+
+to:
+
+```typescript
+if (status === 'addressed' || status === 'resolved') {
+```
+
+This gives `addressed` annotations the same Reopen + follow-up note capability that `resolved` annotations already have. The reviewer can then push back on the agent's work whilst preserving the full conversation history.
+
+### Updated Button Matrix After Fix
+
+```
++--------------+---------+---------+---------+
+|   Status     | Delete  | Accept  | Reopen  |
++--------------+---------+---------+---------+
+| open         |   Yes   |   No    |   No    |
+| in_progress  |   No    |   No    |   No    |
+| addressed    |   No    |   Yes   |   Yes   | <-- Fixed
+| resolved     |   No    |   Yes   |   Yes   |
++--------------+---------+---------+---------+
+```
+
+### Updated Workflow After Fix
+
+```
+  Agent resolves annotation (default)
+       |
+       v
+  Status: "addressed"
+       |
+  Reviewer sees: [Accept] [Reopen]
+       |
+  +----+----+
+  v         v
+Accept    Reopen (shows textarea for follow-up note)
+  |         |
+  v         v
+DELETED   Status: "open"
+          + optional reviewer reply appended
+          Agent can see feedback and re-address
+```
+
+### Files to Update
+
+| File | Change |
+|------|--------|
+| `src/client/ui/panel.ts` | `appendStatusActions()`: add `addressed` to Reopen condition |
+| `tests/client/ui/panel.test.ts` | Add test: "shows Reopen button on addressed annotation" |
+| `tests/client/ui/panel.test.ts` | Update test: "does not show Reopen button on open annotation" (confirm no regression) |
+| `docs/spec/specification.md` | Update section 6.2.3c button visibility table |
+| `docs/guides/2026-02-28-annotation-status-workflows.md` | Update button matrix and diagrams |
+
+## Issue #2: Semantic Mismatch Between `addressed` and `resolved`
+
+### Observation
+
+The distinction between `addressed` and `resolved` has shifted across PRs:
+
+- **Original spec** (pre-PR #32): `resolved` meant "human reviewer accepted the work"
+- **After PR #32**: `resolved` was redefined to mean "agent auto-resolved, skipping human review"
+
+This creates a semantic inversion:
+- `addressed` = "awaiting human review" but has **fewer** reviewer actions (only Accept)
+- `resolved` = "skipped human review" but has **more** reviewer actions (Accept + Reopen)
+
+The status that explicitly invites human review (`addressed`) should logically offer more reviewer options, not fewer.
+
+### Recommendation
+
+Fixing Issue #1 (adding Reopen to `addressed`) resolves this semantic mismatch. Both statuses would then offer the same reviewer actions, with the distinction being purely about how they were reached:
+
+- `addressed`: Agent explicitly requested human review
+- `resolved`: Agent auto-resolved; reviewer can still intervene if needed
+
+## Issue #3: Spec Documentation Gaps
+
+### Status Transition Table
+
+The specification at `docs/spec/specification.md` section 5.3 lists the forward transitions clearly but does not document:
+
+1. **Reopen transition**: `resolved` -> `open` (via reviewer Reopen button)
+2. **Missing `addressed` -> `open`**: If Issue #1 is fixed, this transition needs documenting
+
+### Recommended Spec Updates
+
+Add to the status transitions section:
+
+```
+- `addressed` -> `open`: Reviewer clicks Reopen, optionally with follow-up note
+- `resolved` -> `open`: Reviewer clicks Reopen, optionally with follow-up note
+```
+
+## Summary of Issues
+
+| # | Issue | Severity | Status |
+|---|-------|----------|--------|
+| 1 | No Reopen button on `addressed` annotations | High | Fixed |
+| 2 | Semantic mismatch between `addressed`/`resolved` reviewer options | Medium | Fixed (resolved by fixing #1) |
+| 3 | Spec doesn't document reopen transitions | Low | Fixed |
+
+## Action Items
+
+1. **Fix `appendStatusActions()`** to show Reopen on `addressed` annotations
+2. **Add tests** for the new `addressed` + Reopen behaviour
+3. **Update spec** section 6.2.3c and status transitions
+4. **Update the canonical workflow guide** with corrected button matrix

--- a/docs/spec/specification.md
+++ b/docs/spec/specification.md
@@ -198,7 +198,8 @@ open → in_progress → addressed → resolved
 - `open` or `in_progress` → `addressed`: Agent calls `resolve_annotation` MCP tool (default, without `autoResolve`)
 - `open` or `in_progress` → `resolved`: Agent calls `resolve_annotation` with `autoResolve: true` (skips human review step)
 - `addressed` or `resolved` → *(deleted)*: Human reviewer clicks Accept button in panel — annotation is removed entirely
-- `resolved` → `open`: Human reviewer clicks Reopen button in panel (clears all progress timestamps)
+- `addressed` → `open`: Human reviewer clicks Reopen button in panel (clears all progress timestamps), optionally with follow-up note
+- `resolved` → `open`: Human reviewer clicks Reopen button in panel (clears all progress timestamps), optionally with follow-up note
 
 **Timestamp semantics**:
 - `inProgressAt` is set when status transitions to `in_progress`
@@ -964,12 +965,12 @@ Each annotation item includes contextual action buttons based on its effective s
 | Status | Buttons shown | Label | `data-air-el` | Action |
 |--------|--------------|-------|---------------|--------|
 | `open` | Delete | "Delete" | `annotation-delete` | Two-click delete (see section 6.2.3d) |
-| `addressed` | Accept | "Accept" | `annotation-accept` | Deletes annotation entirely via `DELETE /annotations/:id` |
+| `addressed` | Accept, Reopen | "Accept", "Reopen" | `annotation-accept`, `annotation-reopen` | Accept deletes annotation; Reopen shows inline form (see below) |
 | `resolved` | Accept, Reopen | "Accept", "Reopen" | `annotation-accept`, `annotation-reopen` | Accept deletes annotation; Reopen shows inline form (see below) |
 
 **Accept button**: Green background (`#166534`), green text (`#86EFAC`). Shown on both `addressed` and `resolved` annotations. Used by the human reviewer to confirm that the agent's work is satisfactory. Sends `DELETE /annotations/:id`, removes highlights, refreshes badge, and refreshes panel. The annotation is removed entirely — accepting means the reviewer is happy with the change and the annotation has served its purpose.
 
-**Reopen button**: Styled as a cancel-type button. Used when the reviewer disagrees with the resolution and wants to re-open the annotation. Instead of immediately changing status, clicking Reopen shows an inline form (`data-air-el="reopen-form"`) with:
+**Reopen button**: Styled as a cancel-type button. Shown on both `addressed` and `resolved` annotations. Used when the reviewer disagrees with the agent's work and wants to re-open the annotation. Instead of immediately changing status, clicking Reopen shows an inline form (`data-air-el="reopen-form"`) with:
 - A textarea (`data-air-el="reopen-textarea"`) for an optional follow-up note, placeholder: "Add a follow-up note (optional)…"
 - A "Cancel" button (`data-air-el="reopen-cancel"`) that dismisses the form without changes
 - A "Reopen" submit button (`data-air-el="reopen-submit"`) that sends `PATCH /annotations/:id` with `{ "status": "open" }` and optionally `{ "reply": { "message": "..." } }` if the reviewer entered a note
@@ -1845,7 +1846,7 @@ The following accessibility features are not yet implemented:
 | Click "+ Note" in panel | Add-note form appears/toggles | 11.2 |
 | Click "Copy All" in panel | Export all annotations to clipboard, show toast | 9.3 |
 | Click Accept on addressed or resolved annotation | Annotation is deleted entirely (removed from store, highlights cleared) | 6.2.3c |
-| Click Reopen on resolved annotation | Shows inline form for optional follow-up note, then reopens | 6.2.3c |
+| Click Reopen on addressed or resolved annotation | Shows inline form for optional follow-up note, then reopens | 6.2.3c |
 | Click Delete on annotation in panel | Two-click confirmation: first click shows "Sure?", second click deletes | 6.2.3, 6.2.3a |
 | Click "Clear All" in panel | Confirmation step, then deletes all | 6.2.5 |
 | Press Escape | Dismiss popup (priority) or close panel | 10.4 |

--- a/src/client/ui/panel.ts
+++ b/src/client/ui/panel.ts
@@ -740,7 +740,7 @@ function appendStatusActions(
     container.appendChild(acceptBtn);
   }
 
-  if (status === 'resolved') {
+  if (status === 'addressed' || status === 'resolved') {
     const reopenBtn = document.createElement('button');
     reopenBtn.className = 'air-popup__btn air-popup__btn--cancel';
     reopenBtn.setAttribute('data-air-el', 'annotation-reopen');

--- a/tests/client/ui/panel.test.ts
+++ b/tests/client/ui/panel.test.ts
@@ -1022,6 +1022,18 @@ describe('createPanel — status lifecycle buttons', () => {
     expect(acceptBtn).toBeNull();
   });
 
+  it('shows Reopen button on addressed annotation', async () => {
+    await renderWithStore({
+      version: 1,
+      annotations: [makeTextAnnotation({ status: 'addressed', addressedAt: '2026-02-22T10:00:00Z' })],
+      pageNotes: [],
+    });
+
+    const reopenBtn = shadowRoot.querySelector('[data-air-el="annotation-reopen"]');
+    expect(reopenBtn).not.toBeNull();
+    expect(reopenBtn!.tagName.toLowerCase()).toBe('button');
+  });
+
   it('shows Reopen button on resolved annotation', async () => {
     await renderWithStore({
       version: 1,


### PR DESCRIPTION
## Summary

- **Fix**: Add `addressed` status to Reopen button condition in `appendStatusActions()` — reviewers can now push back on agent work with follow-up notes instead of being forced to Accept (delete) or create a new annotation from scratch
- **Spec**: Update section 6.2.3c button visibility table, status transitions, and acceptance test table
- **Docs**: Add canonical annotation status workflow guide and status review document identifying the gap

## Context

The default MCP `resolve_annotation` call produces `addressed` status, but the Reopen button only appeared on `resolved` annotations. This meant the most common agent workflow left reviewers unable to provide follow-up feedback — a design gap identified during investigation of PR #32 and PR #33.

## Test plan

- [x] New test: shows Reopen button on addressed annotation
- [x] All 477 tests pass (up from 476)
- [x] Build succeeds
- [x] Lint clean