### PR TITLE
fix: make element annotation pulse visually equivalent to text pulse

### DIFF
--- a/docs/reviews/2026-02-28-fix-26-element-pulse-review.md
+++ b/docs/reviews/2026-02-28-fix-26-element-pulse-review.md
@@ -1,0 +1,90 @@
+---
+generated_by: Claude Opus 4.6
+generation_date: 2026-02-28
+model_version: claude-opus-4-6
+purpose: independent_review
+status: draft
+human_reviewer: matthewvivian
+tags: [fix, highlight, animation, element-annotation, review]
+---
+
+# Independent Review: Fix #26 — Element Annotation Pulse Visibility
+
+**PR**: #42 (`fix/26-element-pulse-visibility`)
+**Issue**: #26 — element annotation pulse on panel click is too subtle to notice
+**Commit**: `30ea610` — `fix: make element annotation pulse visually equivalent to text pulse`
+
+## Summary
+
+The PR redesigns `pulseElementHighlight()` to be visually equivalent to the text annotation pulse. The previous implementation only animated `outline-color` from 80% to 100% opacity — a 25% relative change on a thin dashed border. The new implementation adds a background flash (`rgba(217,119,6,0.15)`) and box-shadow glow (`0 0 0 4px rgba(217,119,6,0.3)`) alongside the outline change, making the pulse immediately noticeable.
+
+## Changes Reviewed
+
+### Source: `src/client/highlights.ts`
+
+- `pulseElementHighlight()` (lines 141-164): Saves original `backgroundColor` and `boxShadow`, applies background flash + box-shadow + brighter outline, then restores originals at 600ms and cleans up transition/attribute at 900ms
+- Text highlight pulse (`pulseHighlight()`, lines 86-101): Unchanged — confirmed identical to `main`
+
+### Tests: `tests/client/highlights.test.ts`
+
+- 9 new tests for `pulseElementHighlight()` covering: attribute set, background flash, box-shadow, outline brightening, restoration at 600ms, cleanup at 900ms, no-op on missing element, and pre-existing background preservation
+- 4 new tests for `pulseHighlight()` (text) verifying existing behaviour is documented and locked down
+- All tests use `vi.useFakeTimers()` for deterministic timing
+
+## Findings
+
+### F1: Style Leak on Mid-Pulse Deletion (Severity: Medium)
+
+`removeElementHighlight()` clears `outline`, `outlineOffset`, and `cursor`, but does not clear `backgroundColor`, `boxShadow`, or `transition` — all properties now set by the pulse. If an element annotation is deleted while a pulse is in-flight (user clicks panel "locate" then quickly deletes), the pending `setTimeout` callbacks will fire on an element that has already had its highlight removed, and the styles set during the pulse will never be cleaned up.
+
+**Scenario**: User clicks annotation in panel (triggers pulse), then immediately clicks delete on that annotation. The `removeElementHighlight` runs, clearing `outline`/`outlineOffset`/`cursor` and removing the attribute. But the 600ms and 900ms timeouts still fire, and since the element is found by attribute (which was already removed), the timeouts safely no-op — the `querySelector` returns `null`. However, the background and box-shadow set at pulse start are never removed, because `removeElementHighlight` doesn't know about them.
+
+**Wait** — re-reading the code more carefully: the timeout callbacks reference the `el` variable captured in the closure, not a new DOM query. So they *will* fire on the captured element reference. But `removeElementHighlight` queries for the element by attribute and clears `outline`, `outlineOffset`, `cursor`, and removes the attribute. The captured `el` still has `backgroundColor` and `boxShadow` set from the pulse start, and the 600ms callback restores `origBg` and `origBoxShadow`. So actually: the 600ms callback would clear the background and box-shadow (restoring originals), and the 900ms callback clears transition and removes `data-air-pulse`. The style leak risk is narrow — it only occurs if `removeElementHighlight` runs *after* the pulse starts but *before* the 600ms timeout fires, AND the page element persists (not navigated away). In practice this is low risk because:
+1. The 600ms timeout will still fire and restore originals
+2. The element loses its annotation attribute so the stale styles are cosmetic only
+
+**Recommendation**: Update `removeElementHighlight()` to also clear `backgroundColor`, `boxShadow`, and `transition` as a defensive measure. This is cheap and eliminates any edge-case leakage.
+
+### F2: Specification Section 8.5.3 Not Updated (Severity: Medium)
+
+The spec (Section 8.5.3, lines 1303-1311) still describes the old pulse behaviour: `transition: outline-color 0.3s ease` and animating only outline opacity. The new implementation transitions three properties (`background-color`, `box-shadow`, `outline-color`) and adds background flash + box-shadow. The spec must be updated to reflect the new design.
+
+### F3: Colour Palette Section 17.1 Missing New Tokens (Severity: Low)
+
+Section 17.1 (line 1705) lists `Element highlight pulse | rgba(217,119,6,1)` for the outline, but does not document:
+- Element pulse background: `rgba(217,119,6,0.15)`
+- Element pulse box-shadow: `rgba(217,119,6,0.3)` (same value as text highlight background, but used differently)
+
+These should be added for completeness and so future maintainers know all colour values in use.
+
+### F4: No Engineering Plan Document (Severity: Low)
+
+Issue #26 lists "Engineering plan created as a markdown document" as a quality gate. No engineering plan was found in `docs/engineering-plans/`. For a small, focused fix like this, the issue description itself provides adequate context, but the quality gate is technically unmet.
+
+### F5: Test Imports Include Unused `applyElementHighlight` (Severity: Trivial)
+
+Line 7 of the test file imports `applyElementHighlight` but no test uses it directly (the tests set up DOM with raw HTML). This is not harmful but is slightly untidy. ESLint doesn't flag it, so this may be acceptable as intentional (future use).
+
+**Update**: On reflection, ESLint with typescript-eslint would typically flag unused imports. Since lint passes, this import may be used implicitly or the rule may not be configured. Either way, trivial.
+
+## Documentation Scan
+
+| Document | Status | Notes |
+|----------|--------|-------|
+| `docs/spec/specification.md` Section 8.5.3 | Needs update | Still describes old outline-only pulse |
+| `docs/spec/specification.md` Section 17.1 | Needs update | Missing new colour tokens |
+| `docs/spec/specification.md` Section 8.3 | OK | Text pulse unchanged, spec accurate |
+| `CLAUDE.md` | OK | No changes needed |
+| Engineering plan | Missing | Quality gate unmet (see F4) |
+
+## Verdict
+
+**Approve with findings**. The core implementation is correct, well-tested, and solves the issue effectively. The pulse is now visually equivalent to the text annotation pulse. The `setTimeout`-based animation pattern is clean and consistent with the existing text pulse.
+
+Three items need attention before merge:
+
+1. **F1**: Update `removeElementHighlight()` to defensively clear the new style properties (medium — prevents style leak edge case)
+2. **F2**: Update spec Section 8.5.3 to document the new pulse design (medium — spec accuracy)
+3. **F3**: Add missing colour tokens to Section 17.1 (low — completeness)
+
+F4 (missing engineering plan) and F5 (unused import) are noted but not blocking.

--- a/docs/spec/specification.md
+++ b/docs/spec/specification.md
@@ -1297,18 +1297,24 @@ All element highlights share:
 When an element annotation is deleted:
 
 1. Find the element with `data-air-element-id="<id>"`
-2. Remove the inline `outline`, `outline-offset`, and `cursor` styles
-3. Remove the `data-air-element-id` attribute
+2. Remove the `data-air-element-id` and `data-air-pulse` attributes
+3. Remove the inline `outline`, `outline-offset`, and `cursor` styles
+4. Defensively clear `backgroundColor`, `boxShadow`, and `transition` (may be set by a mid-flight pulse animation)
 
 #### 8.5.3 Element Highlight Pulse
 
-When scrolling to an element annotation from the panel:
+When scrolling to an element annotation from the panel, the element "pulses" with a background flash and box-shadow glow (matching the visual impact of the text highlight pulse):
 
 1. Set `data-air-pulse` attribute on the element (same test hook as text highlights)
-2. Set `transition: outline-color 0.3s ease`
-3. Change outline to `rgba(217,119,6,1)` (fully opaque)
-4. After 600ms: revert to `rgba(217,119,6,0.8)` (normal)
-5. After 900ms: remove the transition and `data-air-pulse` attribute
+2. Save original `backgroundColor` and `boxShadow` values (to restore after animation)
+3. Set `transition: background-color 0.3s ease, box-shadow 0.3s ease, outline-color 0.3s ease`
+4. Change outline to `rgba(217,119,6,1)` (fully opaque)
+5. Set `backgroundColor` to `rgba(217,119,6,0.15)` (subtle amber flash)
+6. Set `boxShadow` to `0 0 0 4px rgba(217,119,6,0.3)` (amber glow)
+7. After 600ms: revert outline to `rgba(217,119,6,0.8)`, restore original `backgroundColor` and `boxShadow`
+8. After 900ms: remove the transition and `data-air-pulse` attribute
+
+**Design rationale**: The previous implementation only animated `outline-color` from 80% to 100% opacity — a 25% relative change on a thin dashed border that was nearly imperceptible. The background flash and box-shadow glow provide a filled-area visual cue that matches the noticeability of the text highlight pulse (see Section 8.3).
 
 #### 8.5.4 Element Highlight Restoration
 
@@ -1702,7 +1708,9 @@ Errors are logged with the prefix `[astro-inline-review]` for easy filtering. No
 | Inspector label text | `white` | White text on tag label |
 | Element highlight outline (open) | `rgba(217,119,6,0.8)` | Dashed amber outline on open annotated elements |
 | Element highlight outline (addressed) | `rgba(59,130,246,0.5)` | Dashed blue outline on addressed annotated elements |
-| Element highlight pulse | `rgba(217,119,6,1)` | Fully opaque amber outline during pulse |
+| Element highlight pulse outline | `rgba(217,119,6,1)` | Fully opaque amber outline during pulse |
+| Element highlight pulse background | `rgba(217,119,6,0.15)` | Subtle amber background flash during pulse |
+| Element highlight pulse glow | `rgba(217,119,6,0.3)` | Amber box-shadow glow during pulse (`0 0 0 4px`) |
 | In-progress text highlight | `rgba(139,92,246,0.2)` | Purple background on in-progress text annotations |
 | Addressed text highlight | `rgba(59,130,246,0.2)` | Blue background on addressed text annotations |
 | In-progress element outline | `rgba(139,92,246,0.5)` | Dashed purple outline on in-progress annotated elements |

--- a/src/client/highlights.ts
+++ b/src/client/highlights.ts
@@ -128,9 +128,14 @@ export function removeElementHighlight(id: string): void {
   const el = document.querySelector(`[${ELEMENT_HIGHLIGHT_ATTR}="${CSS.escape(id)}"]`) as HTMLElement | null;
   if (!el) return;
   el.removeAttribute(ELEMENT_HIGHLIGHT_ATTR);
+  el.removeAttribute('data-air-pulse');
   el.style.outline = '';
   el.style.outlineOffset = '';
   el.style.cursor = '';
+  // Clear properties that may be set by a mid-flight pulse animation
+  el.style.backgroundColor = '';
+  el.style.boxShadow = '';
+  el.style.transition = '';
 }
 
 /**

--- a/tests/client/highlights.test.ts
+++ b/tests/client/highlights.test.ts
@@ -5,6 +5,7 @@ import {
   getHighlightMarks,
   pulseHighlight,
   applyElementHighlight,
+  removeElementHighlight,
   pulseElementHighlight,
   HIGHLIGHT_ATTR,
   ELEMENT_HIGHLIGHT_ATTR,
@@ -320,5 +321,41 @@ describe('pulseElementHighlight', () => {
     // After 600ms, original background is restored
     vi.advanceTimersByTime(600);
     expect(el.style.backgroundColor).toBe('rgb(240, 240, 240)');
+  });
+});
+
+describe('removeElementHighlight — mid-pulse cleanup', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears pulse styles when highlight is removed mid-animation', () => {
+    document.body.innerHTML = '<div data-air-element-id="el-1" style="outline: 2px dashed rgba(217,119,6,0.8); outline-offset: 2px; cursor: pointer;">content</div>';
+
+    // Start pulse
+    pulseElementHighlight('el-1');
+    const el = document.querySelector('div') as HTMLElement;
+
+    // Verify pulse styles are active
+    expect(el.style.backgroundColor).toBe('rgba(217, 119, 6, 0.15)');
+    expect(el.style.boxShadow).toBe('0 0 0 4px rgba(217,119,6,0.3)');
+
+    // Remove highlight mid-pulse (simulates user deleting annotation quickly)
+    removeElementHighlight('el-1');
+
+    // All styles should be cleared, including pulse properties
+    expect(el.style.outline).toBe('');
+    expect(el.style.outlineOffset).toBe('');
+    expect(el.style.cursor).toBe('');
+    expect(el.style.backgroundColor).toBe('');
+    expect(el.style.boxShadow).toBe('');
+    expect(el.style.transition).toBe('');
+    expect(el.hasAttribute('data-air-pulse')).toBe(false);
+    expect(el.hasAttribute('data-air-element-id')).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #26

## Summary
- Redesigned `pulseElementHighlight()` with a temporary background flash (`rgba(217,119,6,0.15)`) and box-shadow glow (`0 0 0 4px rgba(217,119,6,0.3)`) in addition to the existing outline colour change
- Element pulse is now as noticeable as text annotation pulse
- Text pulse behaviour unchanged

## Test plan
- [x] Unit tests for new element pulse animation (background flash, box-shadow, outline colour, restore timing, pre-existing background preservation)
- [x] Text pulse tests unchanged
- [x] All 475 tests pass
- [x] Lint passes
- [x] Build succeeds
