### PR TITLE
fix: prevent intermittent false orphan state on reload (#40)

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -248,6 +248,10 @@ function init(): void {
 
   // Restore highlights for the current page, then handle pending scroll-to
   annotator.restoreHighlights().then(() => {
+    // Refresh panel after highlights so orphan states reflect DOM reality
+    if (isPanelOpen(panel)) {
+      mediator.refreshPanel();
+    }
     const pendingId = sessionStorage.getItem(SCROLL_TO_KEY);
     if (pendingId) {
       sessionStorage.removeItem(SCROLL_TO_KEY);
@@ -258,6 +262,9 @@ function init(): void {
   // Re-restore on Astro page transitions (also handles pending scroll-to)
   document.addEventListener('astro:page-load', () => {
     annotator.restoreHighlights().then(() => {
+      if (isPanelOpen(panel)) {
+        mediator.refreshPanel();
+      }
       const pendingId = sessionStorage.getItem(SCROLL_TO_KEY);
       if (pendingId) {
         sessionStorage.removeItem(SCROLL_TO_KEY);
@@ -271,12 +278,12 @@ function init(): void {
     onStoreChanged: () => {
       // Clear orphan timestamps so re-restored annotations get a fresh grace window
       orphanTracker.onStoreChanged();
-      // Always update DOM highlights — they're visible regardless of panel state
-      annotator.restoreHighlights();
-      // Only refresh the panel if it's currently open — avoids unnecessary DOM work
-      if (isPanelOpen(panel)) {
-        mediator.refreshPanel();
-      }
+      // Refresh panel AFTER highlights so orphan states reflect DOM reality
+      annotator.restoreHighlights().then(() => {
+        if (isPanelOpen(panel)) {
+          mediator.refreshPanel();
+        }
+      });
     },
   });
   poller.start();


### PR DESCRIPTION
## Summary

- Fixes race condition between `refreshPanel()` and `restoreHighlights()` during page initialisation that caused intermittent "Could not locate on page" for addressed annotations
- Sequences panel refresh **after** highlight restoration at three call sites: initial page load, Astro page transitions, and store poller
- Retains the early `refreshPanel()` at page load for responsiveness; the post-highlights refresh corrects orphan states once anchoring completes

## Root cause

Both `refreshPanel()` and `restoreHighlights()` are async and make independent HTTP requests. Whichever completes first determines the outcome. If the panel renders before highlights exist in DOM, `getOrphanState()` sees no anchors and `OrphanTracker` (freshly constructed on reload) returns `'orphaned'` immediately — no grace period applies. After `restoreHighlights()` completes, no follow-up panel refresh occurred, so the stale orphan state persisted.

## Test plan

- [x] `npm run build` — TypeScript compiles
- [x] `npm test` — 463 tests pass, no regressions
- [x] `npm run lint` — no lint issues
- [ ] Manual: annotate text, have agent address with `replacedText`, reload repeatedly with panel open — "Could not locate on page" should not appear

Fixes #40
