### PR TITLE
fix: update express-rate-limit to resolve CI audit failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3874,12 +3874,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -4579,9 +4579,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Summary

- Updates express-rate-limit from 8.2.1 to 8.3.0 (transitive dependency via @modelcontextprotocol/sdk)
- Resolves high-severity vulnerability GHSA-46wh-pxpv-q5gq (IPv4-mapped IPv6 addresses bypass per-client rate limiting on dual-stack servers)
- Fixes the failing CI pipeline npm audit check

## Verification

- \`npm audit --audit-level=high --omit=dev\` reports 0 vulnerabilities
- Build passes
- All 528 tests pass

## Test plan

- [x] \`npm audit\` shows no high-severity vulnerabilities
- [x] \`npm run build\` succeeds
- [x] \`npm test\` passes (528/528)
- [x] CI pipeline passes audit check